### PR TITLE
SC9 StringUtils::formatTime and timestamped log files

### DIFF
--- a/codebase/src/cpp/syscommon/include/syscommon/util/StringUtils.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/util/StringUtils.h
@@ -163,5 +163,90 @@ namespace syscommon
 			 */
 			static std::vector<String> stringSplit( const String& source, 
 			                                        const String& delimiter );
+
+			/**
+			 * Formats the specified time value using the provided format string and returns the
+			 * result.
+			 * <br/><br/>
+			 * The format string can contain any combination of regular characters and special 
+			 * format specifiers. These format specifiers are replaced by the function to the 
+			 * corresponding values to represent the time specified in the <code>time</code> 
+			 * parameter. The format specifiers all begin with the percentage (%) sign and are:
+			 *
+			 * <table>
+			 *	<tr>
+			 *		<th>Specifier</th><th>Replaced By</th><th>Example</th>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%a</td><td>Abbreviated weekday name *</td><td>Thu</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%A</td><td>Full weekday name *</td><td>Thursday</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%b</td><td>Abbreviated month name *</td><td>Aug</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%B</td><td>Full month name *</td><td>August</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%c</td><td>Date and time representation *</td><td>Thu Aug 23 14:55:02 2001</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%d</td><td>Day of the month, zero-padded (01-31)</td><td>23</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%H</td><td>Hour in 24h format (00-23)</td><td>14</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%H</td><td>Hour in 12h format (01-22)</td><td>02</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%j</td><td>Day of the year (001-366)</td><td>235</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%m</td><td>Month as a decimal number (01-12)</td><td>08</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%M</td><td>Minute (00-59)</td><td>55</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%p</td><td>AM or PM designation</td><td>PM</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%S</td><td>Second (00-61)</td><td>02</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%w</td><td>Weekday as a decimal number with Sunday as 0 (0-6)</td><td>4</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%W</td><td>Week number with the first Monday as the first day of week one (00-53)</td><td>34</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%x</td><td>Date representation *</td><td>08/23/01</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%X</td><td>Time representation *</td><td>14:55:02</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%y</td><td>Year, last two digits (00-99)</td><td>01</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%Y</td><td>Year</td><td>2001</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%Z</td><td>Timezone name or abbreviation *</td><td>CDT</td>
+			 *	</tr>
+			 *	<tr>
+			 *		<td>%%</td><td>A % sign</td><td>%</td>
+			 *	</tr>
+			 * </table>
+			 *	* The specifiers marked with an asterisk (*) are locale-dependent.
+			 *
+			 * @param time the time value to format
+			 * @param format a format string containing any combination of regular characters and 
+			 *               special format specifiers.
+			 */
+			static String formatTime( const time_t& time, const String& format );
 	};
 }

--- a/codebase/src/cpp/syscommon/src/Logger.cpp
+++ b/codebase/src/cpp/syscommon/src/Logger.cpp
@@ -15,6 +15,7 @@
 #include "syscommon/util/Logger.h"
 
 #include <cstdio>
+#include <ctime>
 #include "syscommon/util/StringUtils.h"
 
 #pragma warning( disable : 4996 )
@@ -91,7 +92,7 @@ void Logger::fatal( const tchar* format, ... )
 		// start the var-arg stuff
 		va_list args;
 		va_start( args, format );
-		log( TEXT("FATAL"), format, args );
+		log( TEXT("[FATAL]"), format, args );
 		// do the varargs cleanup
 		va_end( args );
 	}
@@ -104,7 +105,7 @@ void Logger::error( const tchar* format, ... )
 		// start the var-arg stuff
 		va_list args;
 		va_start( args, format );
-		log( TEXT("ERROR"), format, args );
+		log( TEXT("[ERROR]"), format, args );
 		// do the varargs cleanup
 		va_end( args );
 	}
@@ -117,7 +118,7 @@ void Logger::warn( const tchar* format, ... )
 		// start the var-arg stuff
 		va_list args;
 		va_start( args, format );
-		log( TEXT("WARN"), format, args );
+		log( TEXT(" [WARN]"), format, args );
 		// do the varargs cleanup
 		va_end( args );
 	}
@@ -130,7 +131,7 @@ void Logger::info( const tchar* format, ... )
 		// start the var-arg stuff
 		va_list args;
 		va_start( args, format );
-		log( TEXT("INFO"), format, args );
+		log( TEXT(" [INFO]"), format, args );
 		// do the varargs cleanup
 		va_end( args );
 	}
@@ -143,7 +144,7 @@ void Logger::debug( const tchar* format, ... )
 		// start the var-arg stuff
 		va_list args;
 		va_start( args, format );
-		log( TEXT("DEBUG"), format, args );
+		log( TEXT("[DEBUG]"), format, args );
 		// do the varargs cleanup
 		va_end( args );
 	}
@@ -156,7 +157,7 @@ void Logger::trace( const tchar* format, ... )
 		// start the var-arg stuff
 		va_list args;
 		va_start( args, format );
-		log( TEXT("TRACE"), format, args );
+		log( TEXT("[TRACE]"), format, args );
 		// do the varargs cleanup
 		va_end( args );
 	}
@@ -167,10 +168,12 @@ void Logger::log( const tchar* level, const tchar* message )
 	lock.lock();
 	if( isStarted() )
 	{
+		String time = StringUtils::formatTime( ::time(NULL), TEXT("%Y-%m-%d %H:%M:%S") );
+
 #ifndef UNICODE
-		fprintf( file, TEXT("[%s] %s\n"), level, message );
+		fprintf( file, TEXT("%s %s %s\n"), time.c_str(), level, message );
 #else
-		fwprintf( file, TEXT("[%ls] %ls\n"), level, message );
+		fwprintf( file, TEXT("$ls %ls %ls\n"), time.c_str(), level, message );
 #endif
 		fflush( file );
 	}
@@ -182,11 +185,13 @@ void Logger::log( const tchar* level, const tchar* format, va_list args )
 	lock.lock();
 	if( isStarted() )
 	{
+		String time = StringUtils::formatTime( ::time(NULL), TEXT("%Y-%m-%d %H:%M:%S") );
+
 #ifndef UNICODE
 		char buffer[MAX_MSG_LENGTH];
 		vsprintf( buffer, format, args );
 
-		fprintf( file, TEXT("[%s] %s\n"), level, buffer );
+		fprintf( file, TEXT("%s %s %s\n"), time.c_str(), level, buffer );
 #else
 		
 #endif

--- a/codebase/src/cpp/syscommon/src/StringUtils.cpp
+++ b/codebase/src/cpp/syscommon/src/StringUtils.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "syscommon/util/StringUtils.h"
+#include <time.h>
 #include <wctype.h>
 
 using namespace syscommon;
@@ -152,4 +153,19 @@ std::vector<String> StringUtils::stringSplit( const String& source, const String
 	result.push_back( lastEntry );
 
 	return result;
+}
+
+String StringUtils::formatTime( const time_t& time, const String& format )
+{
+	char buffer[2048];
+
+	// Get the local time, and string format in narrow chars
+	tm* timeLocal = ::localtime( &time );
+	std::string narrowFormat = Platform::toAnsiString( format.c_str() );
+
+	// Perform the format
+	size_t length = ::strftime( buffer, 1024, narrowFormat.c_str(), timeLocal );
+
+	// Convert back to platform string and return
+	return Platform::toPlatformString( buffer, length );
 }


### PR DESCRIPTION
PR raised in response to https://github.com/michaelrfraser/syscommon/issues/9

- Added method StringUtils::formatTime()
- The logger now right-aligns the log level marker
- All log entries are now timestamped