### PR TITLE
SC-11 Added support for VC12 runtime (VS2013)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 /codebase/scripts/windows/vc10/**/*.user
 /codebase/scripts/windows/vc10/**/*.sdf
 /codebase/scripts/windows/vc10/**/*.suo
+/codebase/scripts/windows/vc12/ipch
+/codebase/scripts/windows/vc12/**/*.user
+/codebase/scripts/windows/vc12/**/*.sdf
+/codebase/scripts/windows/vc12/**/*.suo

--- a/codebase/scripts/windows/vc12.bat
+++ b/codebase/scripts/windows/vc12.bat
@@ -1,0 +1,11 @@
+@echo off
+call "%VS120COMNTOOLS%\vsvars32.bat"
+devenv scripts\windows\vc12\vc12.sln /Rebuild "Ansi Debug|Win32"
+devenv scripts\windows\vc12\vc12.sln /Rebuild "Ansi Release|Win32"
+devenv scripts\windows\vc12\vc12.sln /Rebuild "Unicode Debug|Win32"
+devenv scripts\windows\vc12\vc12.sln /Rebuild "Unicode Release|Win32"
+
+devenv scripts\windows\vc12\vc12.sln /Rebuild "Ansi Debug|x64"
+devenv scripts\windows\vc12\vc12.sln /Rebuild "Ansi Release|x64"
+devenv scripts\windows\vc12\vc12.sln /Rebuild "Unicode Debug|x64"
+devenv scripts\windows\vc12\vc12.sln /Rebuild "Unicode Release|x64"

--- a/codebase/scripts/windows/vc12/syscommon/syscommon.vcxproj
+++ b/codebase/scripts/windows/vc12/syscommon/syscommon.vcxproj
@@ -1,0 +1,330 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Ansi Debug|Win32">
+      <Configuration>Ansi Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Ansi Debug|x64">
+      <Configuration>Ansi Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Ansi Release|Win32">
+      <Configuration>Ansi Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Ansi Release|x64">
+      <Configuration>Ansi Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Unicode Debug|Win32">
+      <Configuration>Unicode Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Unicode Debug|x64">
+      <Configuration>Unicode Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Unicode Release|Win32">
+      <Configuration>Unicode Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Unicode Release|x64">
+      <Configuration>Unicode Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}</ProjectGuid>
+    <RootNamespace>syscommon</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Ansi Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Ansi Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Debug|Win32'">
+    <OutDir>$(SolutionDir)..\..\..\dist\vc12\</OutDir>
+    <IntDir>$(SolutionDir)..\..\..\build\$(ProjectName)\vc12\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>syscommond</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Debug|x64'">
+    <IntDir>$(SolutionDir)..\..\..\build\$(ProjectName)\vc12\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>syscommon64d</TargetName>
+    <OutDir>$(SolutionDir)..\..\..\dist\vc12\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'">
+    <OutDir>$(SolutionDir)..\..\..\dist\vc12\</OutDir>
+    <IntDir>$(SolutionDir)..\..\..\build\$(ProjectName)\vc12\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>syscommonud</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|x64'">
+    <IntDir>$(SolutionDir)..\..\..\build\$(ProjectName)\vc12\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>syscommon64ud</TargetName>
+    <OutDir>$(SolutionDir)..\..\..\dist\vc12\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Release|Win32'">
+    <OutDir>$(SolutionDir)..\..\..\dist\vc12\</OutDir>
+    <IntDir>$(SolutionDir)..\..\..\build\$(ProjectName)\vc12\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>syscommon</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Release|x64'">
+    <IntDir>$(SolutionDir)..\..\..\build\$(ProjectName)\vc12\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>syscommon64</TargetName>
+    <OutDir>$(SolutionDir)..\..\..\dist\vc12\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'">
+    <OutDir>$(SolutionDir)..\..\..\dist\vc12\</OutDir>
+    <IntDir>$(SolutionDir)..\..\..\build\$(ProjectName)\vc12\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>syscommonu</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|x64'">
+    <IntDir>$(SolutionDir)..\..\..\build\$(ProjectName)\vc12\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>syscommon64u</TargetName>
+    <OutDir>$(SolutionDir)..\..\..\dist\vc12\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>syscommond</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>syscommon</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">DEBUG</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">DEBUG</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">DEBUG</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">DEBUG</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>IPHLPAPI.lib;wsock32.lib;ADVAPI32.lib;</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>IPHLPAPI.lib;wsock32.lib;ADVAPI32.lib;</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <PreprocessorDefinitions>DEBUG;UNICODE</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>IPHLPAPI.lib;wsock32.lib;ADVAPI32.lib;</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>IPHLPAPI.lib;wsock32.lib;ADVAPI32.lib;</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>IPHLPAPI.lib;wsock32.lib;ADVAPI32.lib;</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ansi Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>IPHLPAPI.lib;wsock32.lib;ADVAPI32.lib;</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <PreprocessorDefinitions>UNICODE</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>IPHLPAPI.lib;wsock32.lib;ADVAPI32.lib;</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <AdditionalDependencies>IPHLPAPI.lib;wsock32.lib;ADVAPI32.lib;</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\DatagramPacket.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Event.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\InetSocketAddress.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\InputBuffer.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Lock.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Logger.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\MulticastSocket.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\OutputBuffer.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Platform.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Properties.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Semaphore.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Socket.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\StringUtils.cpp" />
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Thread.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/codebase/scripts/windows/vc12/syscommon/syscommon.vcxproj.filters
+++ b/codebase/scripts/windows/vc12/syscommon/syscommon.vcxproj.filters
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\DatagramPacket.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Event.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\InetSocketAddress.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\InputBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Lock.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Logger.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\MulticastSocket.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\OutputBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Platform.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Properties.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Semaphore.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Socket.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\StringUtils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Thread.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/codebase/scripts/windows/vc12/vc12.sln
+++ b/codebase/scripts/windows/vc12/vc12.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "syscommon", "syscommon\syscommon.vcxproj", "{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Ansi Debug|Win32 = Ansi Debug|Win32
+		Ansi Debug|x64 = Ansi Debug|x64
+		Ansi Release|Win32 = Ansi Release|Win32
+		Ansi Release|x64 = Ansi Release|x64
+		Unicode Debug|Win32 = Unicode Debug|Win32
+		Unicode Debug|x64 = Unicode Debug|x64
+		Unicode Release|Win32 = Unicode Release|Win32
+		Unicode Release|x64 = Unicode Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Ansi Debug|Win32.ActiveCfg = Ansi Debug|Win32
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Ansi Debug|Win32.Build.0 = Ansi Debug|Win32
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Ansi Debug|x64.ActiveCfg = Ansi Debug|x64
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Ansi Debug|x64.Build.0 = Ansi Debug|x64
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Ansi Release|Win32.ActiveCfg = Ansi Release|Win32
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Ansi Release|Win32.Build.0 = Ansi Release|Win32
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Ansi Release|x64.ActiveCfg = Ansi Release|x64
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Ansi Release|x64.Build.0 = Ansi Release|x64
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Unicode Debug|Win32.ActiveCfg = Unicode Debug|Win32
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Unicode Debug|Win32.Build.0 = Unicode Debug|Win32
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Unicode Debug|x64.ActiveCfg = Unicode Debug|x64
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Unicode Debug|x64.Build.0 = Unicode Debug|x64
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Unicode Release|Win32.ActiveCfg = Unicode Release|Win32
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Unicode Release|Win32.Build.0 = Unicode Release|Win32
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Unicode Release|x64.ActiveCfg = Unicode Release|x64
+		{2822FAD8-AC27-46D7-BFAE-E521671E2D0C}.Unicode Release|x64.Build.0 = Unicode Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/codebase/src/cpp/syscommon/include/syscommon/Platform.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/Platform.h
@@ -118,6 +118,7 @@
 
 #include <string>
 #include <set>
+#include <time.h>
 
 namespace syscommon
 {		
@@ -299,6 +300,7 @@ namespace syscommon
 
 			// Time
 			static unsigned long getCurrentTimeMilliseconds();
+			static tm* toLocalTime( const time_t& time );
 			static bool getRandomBytes( char* buffer, size_t length );
 
 #ifdef _WIN32

--- a/codebase/src/cpp/syscommon/src/Platform.cpp
+++ b/codebase/src/cpp/syscommon/src/Platform.cpp
@@ -922,6 +922,14 @@ unsigned long Platform::getCurrentTimeMilliseconds()
 	return time;
 }
 
+tm* Platform::toLocalTime( const time_t& time )
+{
+#pragma warning( push )
+#pragma warning( disable : 4996 )
+	return ::localtime( &time );
+#pragma warning( pop )
+}
+
 bool Platform::getRandomBytes( char* buffer, size_t length )
 {
 	bool result = false;
@@ -1880,6 +1888,11 @@ unsigned long Platform::getCurrentTimeMilliseconds()
 	::gettimeofday( &time, NULL );
 
 	return (time.tv_sec * 1000) + (time.tv_usec / 1000L);
+}
+
+tm* Platform::toLocalTime( const time_t& time )
+{
+	return ::localtime( &time );
 }
 
 bool Platform::getRandomBytes( char* buffer, size_t length )

--- a/codebase/src/cpp/syscommon/src/StringUtils.cpp
+++ b/codebase/src/cpp/syscommon/src/StringUtils.cpp
@@ -14,7 +14,6 @@
  */
 
 #include "syscommon/util/StringUtils.h"
-#include <time.h>
 #include <wctype.h>
 
 using namespace syscommon;
@@ -160,12 +159,12 @@ String StringUtils::formatTime( const time_t& time, const String& format )
 	char buffer[2048];
 
 	// Get the local time, and string format in narrow chars
-	tm* timeLocal = ::localtime( &time );
+	tm* timeLocal = Platform::toLocalTime( time );
 	std::string narrowFormat = Platform::toAnsiString( format.c_str() );
 
 	// Perform the format
 	size_t length = ::strftime( buffer, 1024, narrowFormat.c_str(), timeLocal );
 
 	// Convert back to platform string and return
-	return Platform::toPlatformString( buffer, length );
+	return Platform::toPlatformString( buffer, (int)length );
 }


### PR DESCRIPTION
PR raised in response to Github ticket https://github.com/michaelrfraser/syscommon/issues/11

- Added project and build script for VC12
- Updated .gitignore to ignore transient VC12 files
- Calls to ::getLocalTime have been moved into Platform so that the CRT
  deprecation warnings can be pragma'd out under Windows