### PR TITLE
SC-5 Ensured that all immutable public methods are const where possible

### DIFF
--- a/codebase/src/cpp/syscommon/include/syscommon/concurrent/Thread.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/concurrent/Thread.h
@@ -239,7 +239,7 @@ namespace syscommon
 			 *
 			 * @return The name of this thread
 			 */
-			const tchar* getName();
+			const tchar* getName() const;
 
 			/**
 			 * Interrupts this thread. Any operations within this thread's unit of execution that
@@ -253,7 +253,7 @@ namespace syscommon
 			 *
 			 * @return Whether the current thread is executing.
 			 */
-			bool isAlive();
+			bool isAlive() const;
 
 			/**
 			 * Blocks the current thread indefinately until this thread instance has completed 

--- a/codebase/src/cpp/syscommon/include/syscommon/io/InputBuffer.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/io/InputBuffer.h
@@ -63,7 +63,7 @@ namespace syscommon
 			std::string readUTF() throw ( IOException );
 
 		private:
-			size_t getBytesRemaining();
+			size_t getBytesRemaining() const;
 			void readAndCopy( size_t length, char* dest ) throw ( IOException );
 
 		//----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/include/syscommon/net/DatagramPacket.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/net/DatagramPacket.h
@@ -162,7 +162,7 @@ namespace syscommon
 			 *
 			 * @return the buffer used to receive or send data
 			 */
-			char* getData();
+			char* getData() const;
 
 			/**
 			 * Returns the offset of the data to be sent or the offset of the
@@ -171,7 +171,7 @@ namespace syscommon
 			 * @return the offset of the data to be sent or the offset of the
 			 * data received.
 			 */
-			int getOffset();
+			int getOffset() const;
 
 			/**
 			 * Returns the length of the data to be sent or the length of the
@@ -180,14 +180,14 @@ namespace syscommon
 			 * @return the length of the data to be sent or the length of the
 			 * data received.
 			 */
-			int getLength();
+			int getLength() const;
 
 			/**
 			 * Returns the original length of the data buffer of this packet
 			 *
 			 * @return the original length of the data buffer of this packet
 			 */
-			int getBufferLength();
+			int getBufferLength() const;
 
 			/**
 			 * Returns the IP address of the machine to which this datagram is being
@@ -196,7 +196,7 @@ namespace syscommon
 			 * @return the IP address of the machine to which this datagram is being
 			 * sent or from which the datagram was received.
 			 */
-			NATIVE_IP_ADDRESS getAddress();
+			NATIVE_IP_ADDRESS getAddress() const;
 
 			/**
 			 * Returns the port number on the remote host to which this datagram is
@@ -205,13 +205,13 @@ namespace syscommon
 			 * @return the port number on the remote host to which this datagram is
 			 * being sent or from which the datagram was received.
 			 */
-			unsigned short getPort();
+			unsigned short getPort() const;
 
 			/**
 			 * Gets the InetSocketAddress of the remote host that this packet is being sent to or 
 			 * is coming from.
 			 */
-			InetSocketAddress getSocketAddress();
+			InetSocketAddress getSocketAddress() const;
 
 		//----------------------------------------------------------
 		//                     STATIC METHODS

--- a/codebase/src/cpp/syscommon/include/syscommon/net/InetSocketAddress.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/net/InetSocketAddress.h
@@ -138,7 +138,7 @@ namespace syscommon
 			 *
 			 * @return true if this address represents the loopback interface, otherwise false.
 			 */
-			bool isLoopbackAddress();
+			bool isLoopbackAddress() const;
 
 			/**
 			 * Returns whether the address portion of this InetSocketAddress represents the network
@@ -147,7 +147,7 @@ namespace syscommon
 			 * @return true if this address represents the wildcard interface address, otherwise
 			 * 				false
 			 */
-			bool isAnyAddress();
+			bool isAnyAddress() const;
 
 		////////////////////////////////////////////////////////////////////////////////////////////
 		//////////////////////////////////// Operator Overloads ////////////////////////////////////

--- a/codebase/src/cpp/syscommon/include/syscommon/net/MulticastSocket.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/net/MulticastSocket.h
@@ -133,7 +133,7 @@ namespace syscommon
 			 *
 			 * @return true if the socket is succesfuly bound to an address
 			 */
-			bool isBound();
+			bool isBound() const;
 
 			/**
 			 * Receives a datagram packet from this socket. When this method returns, the 

--- a/codebase/src/cpp/syscommon/include/syscommon/util/Logger.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/util/Logger.h
@@ -59,9 +59,9 @@ namespace syscommon
 		public:
 			bool start( const tchar* filePath, bool append );
 			void stop();
-			bool isStarted();
+			bool isStarted() const;
 
-			Level getLevel();
+			Level getLevel() const;
 			void setLevel( Level newLevel );
 
 			// logging methods
@@ -78,7 +78,7 @@ namespace syscommon
 
 			// this method will return true if messages for the given
 			// level should be printed, false otherwise
-			bool checkLevel( Level messageLevel );
+			bool checkLevel( Level messageLevel ) const;
 
 		//----------------------------------------------------------
 		//                     STATIC METHODS

--- a/codebase/src/cpp/syscommon/src/DatagramPacket.cpp
+++ b/codebase/src/cpp/syscommon/src/DatagramPacket.cpp
@@ -100,37 +100,37 @@ void DatagramPacket::setLength( int length )
 	this->length = length;
 }
 
-char* DatagramPacket::getData()
+char* DatagramPacket::getData() const
 {
 	return this->buffer;
 }
 
-int DatagramPacket::getOffset()
+int DatagramPacket::getOffset() const
 {
 	return this->offset;
 }
 
-int DatagramPacket::getLength()
+int DatagramPacket::getLength() const
 {
 	return this->length;
 }
 
-int DatagramPacket::getBufferLength()
+int DatagramPacket::getBufferLength() const
 {
 	return this->bufferLength;
 }
 
-NATIVE_IP_ADDRESS DatagramPacket::getAddress()
+NATIVE_IP_ADDRESS DatagramPacket::getAddress() const
 {
 	return this->address;
 }
 
-unsigned short DatagramPacket::getPort()
+unsigned short DatagramPacket::getPort() const
 {
 	return this->port;
 }
 
-InetSocketAddress DatagramPacket::getSocketAddress()
+InetSocketAddress DatagramPacket::getSocketAddress() const
 {
 	return InetSocketAddress( address, port );
 }

--- a/codebase/src/cpp/syscommon/src/InetSocketAddress.cpp
+++ b/codebase/src/cpp/syscommon/src/InetSocketAddress.cpp
@@ -129,12 +129,12 @@ const tchar* InetSocketAddress::getHostAddress()
 	return this->addressString.c_str();
 }
 
-bool InetSocketAddress::isLoopbackAddress()
+bool InetSocketAddress::isLoopbackAddress() const
 {
 	return this->address == INADDR_LOOPBACK;
 }
 
-bool InetSocketAddress::isAnyAddress()
+bool InetSocketAddress::isAnyAddress() const
 {
 	return this->address == INADDR_ANY;
 }

--- a/codebase/src/cpp/syscommon/src/InputBuffer.cpp
+++ b/codebase/src/cpp/syscommon/src/InputBuffer.cpp
@@ -144,7 +144,7 @@ std::string InputBuffer::readUTF() throw ( IOException )
 	}
 }
 
-size_t InputBuffer::getBytesRemaining()
+size_t InputBuffer::getBytesRemaining() const
 {
 	return this->dataLength - this->readMarker;
 }

--- a/codebase/src/cpp/syscommon/src/Logger.cpp
+++ b/codebase/src/cpp/syscommon/src/Logger.cpp
@@ -70,12 +70,12 @@ void Logger::stop()
 	}
 }
 
-bool Logger::isStarted()
+bool Logger::isStarted() const
 {
 	return this->file != NULL;
 }
 
-Logger::Level Logger::getLevel()
+Logger::Level Logger::getLevel() const
 {
 	return this->level;
 }
@@ -201,7 +201,7 @@ void Logger::log( const tchar* level, const tchar* format, va_list args )
 	lock.unlock();
 }
 
-bool Logger::checkLevel( Level messageLevel )
+bool Logger::checkLevel( Level messageLevel ) const
 {
 	bool levelEnabled = messageLevel <= this->level;
 	return levelEnabled;

--- a/codebase/src/cpp/syscommon/src/MulticastSocket.cpp
+++ b/codebase/src/cpp/syscommon/src/MulticastSocket.cpp
@@ -158,7 +158,7 @@ bool MulticastSocket::close()
 	return result;
 }
 
-bool MulticastSocket::isBound()
+bool MulticastSocket::isBound() const
 {
 	return this->bound;
 }

--- a/codebase/src/cpp/syscommon/src/Thread.cpp
+++ b/codebase/src/cpp/syscommon/src/Thread.cpp
@@ -109,7 +109,7 @@ Thread::~Thread()
  *
  * @return The name of this thread
  */
-const tchar* Thread::getName()
+const tchar* Thread::getName() const
 {
 	return this->name.c_str();
 }
@@ -131,7 +131,7 @@ void Thread::interrupt()
  *
  * @return Whether the current thread is executing.
  */
-bool Thread::isAlive()
+bool Thread::isAlive() const
 {
 	return this->state == TS_ALIVE;
 }


### PR DESCRIPTION
PR raised in response to https://github.com/michaelrfraser/syscommon/issues/5

- All get/is methods in public classes const qualified where possible