### PR TITLE
SC-6 Added CRT leak reporting and fixed leaks in Socket Test

### DIFF
--- a/codebase/scripts/windows/vc10/syscommon/syscommon.vcxproj
+++ b/codebase/scripts/windows/vc10/syscommon/syscommon.vcxproj
@@ -372,6 +372,9 @@
     <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\StringUtils.cpp" />
     <ClCompile Include="..\..\..\..\src\cpp\syscommon\src\Thread.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\src\cpp\syscommon\src\debug.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/codebase/scripts/windows/vc10/syscommon/syscommon.vcxproj.filters
+++ b/codebase/scripts/windows/vc10/syscommon/syscommon.vcxproj.filters
@@ -61,4 +61,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\src\cpp\syscommon\src\debug.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/codebase/scripts/windows/vc10/test/test.vcxproj
+++ b/codebase/scripts/windows/vc10/test/test.vcxproj
@@ -152,8 +152,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\..\src\cpp\syscommon\include;$(SolutionDir)..\..\..\lib\cppunit\cppunit-1.12.1\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>
-      </PreprocessorDefinitions>
+      <PreprocessorDefinitions>DEBUG</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/codebase/src/cpp/syscommon/src/DatagramPacket.cpp
+++ b/codebase/src/cpp/syscommon/src/DatagramPacket.cpp
@@ -16,6 +16,10 @@
 
 #include <assert.h>
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/Event.cpp
+++ b/codebase/src/cpp/syscommon/src/Event.cpp
@@ -16,6 +16,10 @@
 
 #include <limits.h>
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/InetSocketAddress.cpp
+++ b/codebase/src/cpp/syscommon/src/InetSocketAddress.cpp
@@ -14,6 +14,10 @@
  */
 #include "syscommon/net/InetSocketAddress.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/InputBuffer.cpp
+++ b/codebase/src/cpp/syscommon/src/InputBuffer.cpp
@@ -16,6 +16,10 @@
 
 #include <cstring>
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/Logger.cpp
+++ b/codebase/src/cpp/syscommon/src/Logger.cpp
@@ -18,6 +18,10 @@
 #include <ctime>
 #include "syscommon/util/StringUtils.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 #pragma warning( disable : 4996 )
 
 using namespace syscommon;

--- a/codebase/src/cpp/syscommon/src/MulticastSocket.cpp
+++ b/codebase/src/cpp/syscommon/src/MulticastSocket.cpp
@@ -17,6 +17,10 @@
 #include <assert.h>
 #include <cstring>
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/OutputBuffer.cpp
+++ b/codebase/src/cpp/syscommon/src/OutputBuffer.cpp
@@ -18,6 +18,10 @@
 #include <assert.h>
 #include <cstring>
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/Platform.cpp
+++ b/codebase/src/cpp/syscommon/src/Platform.cpp
@@ -21,6 +21,11 @@
 using namespace syscommon;
 
 #ifdef _WIN32
+
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 #include <Iphlpapi.h>
 #include <wincrypt.h>
 const tchar* Platform::DIRECTORY_SEPARATOR = TEXT("\\");

--- a/codebase/src/cpp/syscommon/src/Properties.cpp
+++ b/codebase/src/cpp/syscommon/src/Properties.cpp
@@ -17,6 +17,10 @@
 #include <cstdio>
 #include "syscommon/util/StringUtils.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 #pragma warning( disable : 4996 )

--- a/codebase/src/cpp/syscommon/src/Semaphore.cpp
+++ b/codebase/src/cpp/syscommon/src/Semaphore.cpp
@@ -21,6 +21,10 @@
 #include "syscommon/concurrent/Thread.h"
 #include "syscommon/util/StringUtils.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/ServerSocket.cpp
+++ b/codebase/src/cpp/syscommon/src/ServerSocket.cpp
@@ -16,6 +16,10 @@
 
 #include <assert.h>
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/Socket.cpp
+++ b/codebase/src/cpp/syscommon/src/Socket.cpp
@@ -16,6 +16,10 @@
 
 #include <assert.h>
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/StringUtils.cpp
+++ b/codebase/src/cpp/syscommon/src/StringUtils.cpp
@@ -16,6 +16,10 @@
 #include "syscommon/util/StringUtils.h"
 #include <wctype.h>
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 String StringUtils::longToString( const long value )

--- a/codebase/src/cpp/syscommon/src/Thread.cpp
+++ b/codebase/src/cpp/syscommon/src/Thread.cpp
@@ -18,6 +18,10 @@
 #include <limits.h>
 #include "syscommon/util/StringUtils.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/syscommon/src/debug.h
+++ b/codebase/src/cpp/syscommon/src/debug.h
@@ -12,36 +12,21 @@
  * enclosed by brackets "[]" replaced with your own identifying information: 
  * Portions Copyright [yyyy] [name of copyright owner]
  */
-#include "syscommon/concurrent/Lock.h"
 
+/**
+ * The contents of this file are only ever included if the DEBUG pre-processor symbol is defined.
+ * This file should only be included in .cpp files, and only after all nominal headers have been
+ * included.
+ */
 #ifdef DEBUG
-#include "debug.h"
+
+	// Redefine new keyword to provide better memory leak reports
+	#if _WIN32 || _WIN64
+		#ifndef DBG_NEW      
+			#define DBG_NEW new ( _NORMAL_BLOCK , __FILE__ , __LINE__ )      
+			#define new DBG_NEW   
+		#endif
+	#endif
+
 #endif
 
-using namespace syscommon;
-
-//----------------------------------------------------------
-//                      CONSTRUCTORS
-//----------------------------------------------------------
-Lock::Lock()
-{
-	Platform::initialiseCriticalSection( mutex );
-}
-
-Lock::~Lock()
-{
-	Platform::destroyCriticalSection( mutex );
-}
-
-//----------------------------------------------------------
-//                    INSTANCE METHODS
-//----------------------------------------------------------
-void Lock::lock()
-{
-	Platform::enterCriticalSection( mutex );
-}
-
-void Lock::unlock()
-{
-	Platform::leaveCriticalSection( mutex );
-}

--- a/codebase/src/cpp/test/Common.cpp
+++ b/codebase/src/cpp/test/Common.cpp
@@ -17,6 +17,10 @@
 	#pragma warning(disable: 4996)
 #endif
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 /*
  * Fail the current test with the given message
  */

--- a/codebase/src/cpp/test/InetSocketAddressTest.cpp
+++ b/codebase/src/cpp/test/InetSocketAddressTest.cpp
@@ -18,6 +18,9 @@
 #include "syscommon/Platform.h"
 #include "syscommon/net/InetSocketAddress.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
 
 CPPUNIT_TEST_SUITE_REGISTRATION( InetSocketAddressTest );
 

--- a/codebase/src/cpp/test/LockTest.cpp
+++ b/codebase/src/cpp/test/LockTest.cpp
@@ -18,6 +18,9 @@
 #include "syscommon/Platform.h"
 #include "syscommon/concurrent/Thread.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
 
 CPPUNIT_TEST_SUITE_REGISTRATION( LockTest );
 

--- a/codebase/src/cpp/test/MulticastSocketTest.cpp
+++ b/codebase/src/cpp/test/MulticastSocketTest.cpp
@@ -18,6 +18,9 @@
 #include "syscommon/Platform.h"
 #include "syscommon/net/MulticastSocket.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
 
 CPPUNIT_TEST_SUITE_REGISTRATION( MulticastSocketTest );
 

--- a/codebase/src/cpp/test/SemaphoreTest.cpp
+++ b/codebase/src/cpp/test/SemaphoreTest.cpp
@@ -18,6 +18,9 @@
 #include "syscommon/Platform.h"
 #include "syscommon/concurrent/Thread.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
 
 CPPUNIT_TEST_SUITE_REGISTRATION( SemaphoreTest );
 

--- a/codebase/src/cpp/test/SocketTest.cpp
+++ b/codebase/src/cpp/test/SocketTest.cpp
@@ -17,7 +17,12 @@
 #include "syscommon/Platform.h"
 #include "syscommon/net/Socket.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 CPPUNIT_TEST_SUITE_REGISTRATION( SocketTest );
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( SocketTest, "SocketTest" );
 
 using namespace std;
 

--- a/codebase/src/cpp/test/SocketTest.h
+++ b/codebase/src/cpp/test/SocketTest.h
@@ -97,6 +97,7 @@ class SocketTest: public CppUnit::TestFixture
 		CPPUNIT_TEST( testAddressConstructor );
 		CPPUNIT_TEST( testAddressConstructorDeadEndpoint );
 		CPPUNIT_TEST( testAddressConstructorAddrNone );
+		CPPUNIT_TEST( testConnect );
 		CPPUNIT_TEST( testConnectDeadEndpoint );
 		CPPUNIT_TEST( testConnectClosed );
 		CPPUNIT_TEST( testConnectAlreadyConnected );

--- a/codebase/src/cpp/test/StringConnection.cpp
+++ b/codebase/src/cpp/test/StringConnection.cpp
@@ -15,6 +15,10 @@
 #include "StringConnection.h"
 #include "syscommon/io/OutputBuffer.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace syscommon;
 
 //----------------------------------------------------------
@@ -78,7 +82,6 @@ void StringConnection::send( const string& data ) throw ( IOException )
 	}
 }
 
-#include <stdio.h>
 void StringConnection::interrupt()
 {
 	if( this->receiveThread )
@@ -89,9 +92,8 @@ void StringConnection::interrupt()
 		{
 			this->socket->close();
 		}
-		catch( IOException& ioe )
+		catch( IOException& )
 		{
-			printf( "Error on socket interrupt: %s\n", ioe.what() );
 			// Log an error?
 		}
 	}
@@ -110,6 +112,7 @@ void StringConnection::join()
 			// Log an error?
 		}
 
+		delete this->receiveThread;
 		this->receiveThread = NULL;
 		delete this->socket;
 		this->socket = NULL;

--- a/codebase/src/cpp/test/StringServer.cpp
+++ b/codebase/src/cpp/test/StringServer.cpp
@@ -14,6 +14,11 @@
  */
 #include "StringServer.h"
 #include <stdio.h>
+
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 //----------------------------------------------------------
 //                      CONSTRUCTORS
 //----------------------------------------------------------
@@ -61,6 +66,7 @@ void StringServer::stop()
 			(*it++)->interrupt();
 		receiveLock.unlock();
 
+		it = this->clients.begin();
 		while( it != this->clients.end() )
 		{
 			StringConnection* connection = *it++;

--- a/codebase/src/cpp/test/StringUtilsTest.cpp
+++ b/codebase/src/cpp/test/StringUtilsTest.cpp
@@ -16,6 +16,10 @@
 
 #include "syscommon/util/StringUtils.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 using namespace std;
 using namespace syscommon;
 

--- a/codebase/src/cpp/test/ThreadTest.cpp
+++ b/codebase/src/cpp/test/ThreadTest.cpp
@@ -18,6 +18,10 @@
 #include "syscommon/Platform.h"
 #include "syscommon/concurrent/Thread.h"
 
+#ifdef DEBUG
+#include "debug.h"
+#endif
+
 CPPUNIT_TEST_SUITE_REGISTRATION( ThreadTest );
 
 //----------------------------------------------------------

--- a/codebase/src/cpp/test/debug.h
+++ b/codebase/src/cpp/test/debug.h
@@ -12,36 +12,21 @@
  * enclosed by brackets "[]" replaced with your own identifying information: 
  * Portions Copyright [yyyy] [name of copyright owner]
  */
-#include "syscommon/concurrent/Lock.h"
 
+/**
+ * The contents of this file are only ever included if the DEBUG pre-processor symbol is defined.
+ * This file should only be included in .cpp files, and only after all nominal headers have been
+ * included.
+ */
 #ifdef DEBUG
-#include "debug.h"
+
+	// Redefine new keyword to provide better memory leak reports
+	#if _WIN32 || _WIN64
+		#ifndef DBG_NEW      
+			#define DBG_NEW new ( _NORMAL_BLOCK , __FILE__ , __LINE__ )      
+			#define new DBG_NEW   
+		#endif
+	#endif
+
 #endif
 
-using namespace syscommon;
-
-//----------------------------------------------------------
-//                      CONSTRUCTORS
-//----------------------------------------------------------
-Lock::Lock()
-{
-	Platform::initialiseCriticalSection( mutex );
-}
-
-Lock::~Lock()
-{
-	Platform::destroyCriticalSection( mutex );
-}
-
-//----------------------------------------------------------
-//                    INSTANCE METHODS
-//----------------------------------------------------------
-void Lock::lock()
-{
-	Platform::enterCriticalSection( mutex );
-}
-
-void Lock::unlock()
-{
-	Platform::leaveCriticalSection( mutex );
-}

--- a/codebase/src/cpp/test/main.cpp
+++ b/codebase/src/cpp/test/main.cpp
@@ -32,11 +32,22 @@
 	#pragma warning(disable: 4996)
 #endif
 
+#ifdef DEBUG   
+#define _CRTDBG_MAP_ALLOC
+#include <crtdbg.h>
+#include "debug.h"
+#endif
+
 using namespace CPPUNIT_NS;
 using namespace std;
 
 int main( int argc, char* argv[] )
 {
+#ifdef DEBUG
+	_CrtSetDbgFlag ( _CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF );
+	_CrtSetReportMode( _CRT_ERROR, _CRTDBG_MODE_DEBUG );
+#endif
+
 	// check the command line arguments
 	if( argc < 2 )
 	{


### PR DESCRIPTION
PR submitted in response to https://github.com/michaelrfraser/syscommon/issues/6

- Added CRT leak checking in the debug build.
- Found leak in the Socket test due to programming error, which has now been fixed. This may explain why the the unit test suite was crashing in https://github.com/michaelrfraser/syscommon/issues/14. Will investigate once merged.