### PR TITLE
SC-22 Wireless interfaces are now included in available interfaces

### DIFF
--- a/codebase/src/cpp/syscommon/src/Platform.cpp
+++ b/codebase/src/cpp/syscommon/src/Platform.cpp
@@ -742,7 +742,8 @@ std::set<NATIVE_IP_ADDRESS> Platform::getAvailableNetworkInterfaceAddresses()
 		while( currentIface )
 		{
 			// If the current adapter is an ethernet adapter, add it to the set of interfaces
-			if( currentIface->Type == MIB_IF_TYPE_ETHERNET )
+			if( currentIface->Type == MIB_IF_TYPE_ETHERNET || 
+				currentIface->Type == IF_TYPE_IEEE80211 )
 			{
 				syscommon::String platformHostName = 
 					Platform::toPlatformString( currentIface->IpAddressList.IpAddress.String );

--- a/codebase/src/cpp/syscommon/src/Socket.cpp
+++ b/codebase/src/cpp/syscommon/src/Socket.cpp
@@ -175,7 +175,7 @@ void Socket::connect( const InetSocketAddress& endpoint, int timeout ) throw ( I
 			// solely in the tv_usec field, however OSX requires that they be split 
 			// up, returning EINVAL if tv_usec is over 1s worth
 			timeval tv;
-			tv.tv_sec = (int)::floor(timeout / 1000 );
+			tv.tv_sec = (int)::floor((double)timeout / 1000.0 );
 			tv.tv_usec = (timeout - (tv.tv_sec * 1000)) * 1000;
 			fd_set fdset;
 			FD_ZERO( &fdset );


### PR DESCRIPTION
PR for issue https://github.com/michaelrfraser/syscommon/issues/22

- Modified windows implementation of `Platform::getAvailableNetworkInterfaceAddresses()` so that it now
  includes wireless adaptors
- Also fixed Socket code that was causing a compile warning under VC10