### PR TITLE
Removed Dynamic Exception Specifications

### DIFF
--- a/codebase/src/cpp/syscommon/include/syscommon/Exception.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/Exception.h
@@ -31,7 +31,7 @@ namespace syscommon
 
 			}
 
-			virtual ~Exception() throw ()
+			virtual ~Exception() noexcept
 			{
 
 			}
@@ -41,42 +41,42 @@ namespace syscommon
 	{
 		public:
 			IllegalArgumentException( const tchar* message ) : Exception( message ) {}
-			virtual ~IllegalArgumentException() throw () {}
+			virtual ~IllegalArgumentException() noexcept {}
 	};
 
 	class InterruptedException : public Exception
 	{
 		public:
 			InterruptedException( const tchar* message ) : Exception( message ) {}
-			virtual ~InterruptedException() throw () {}
+			virtual ~InterruptedException() noexcept {}
 	};
 
 	class IOException : public Exception
 	{
 		public:
 			IOException( const tchar* message ) : Exception( message ) {}
-			virtual ~IOException() throw () {}
+			virtual ~IOException() noexcept {}
 	};
 
 	class SocketException : public IOException
 	{
 		public:
 			SocketException( const tchar* message ) : IOException( message ) {}
-			virtual ~SocketException() throw () {}
+			virtual ~SocketException() noexcept {}
 	};
 
 	class SocketTimeoutException : public IOException
 	{
 		public:
 			SocketTimeoutException( const tchar* message ) : IOException( message ) {}
-			virtual ~SocketTimeoutException() throw () {}
+			virtual ~SocketTimeoutException() noexcept {}
 	};
 
 	class FileNotFoundException : public IOException
 	{
 		public:
 			FileNotFoundException( const tchar* message ) : IOException( message ) {}
-			virtual ~FileNotFoundException() throw () {}
+			virtual ~FileNotFoundException() noexcept {}
 	};
 }
 

--- a/codebase/src/cpp/syscommon/include/syscommon/concurrent/Semaphore.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/concurrent/Semaphore.h
@@ -85,7 +85,7 @@ namespace syscommon
 			 * @throws InterruptedException if the thread was interrupted before the permit could 
 			 * be acquired.
 			 */
-			void acquire() throw ( InterruptedException );
+			void acquire() noexcept( false );
 
 			/**
 			 * Acquires a permit from this semaphore, if one becomes available within the given 
@@ -97,7 +97,7 @@ namespace syscommon
 			 * @throws InterruptedException if the thread was interrupted before the permit could 
 			 * be acquired.
 			 */
-			bool tryAcquire( unsigned long timeoutMillis ) throw ( InterruptedException );
+			bool tryAcquire( unsigned long timeoutMillis ) noexcept( false );
 
 			/**
 			 * Releases a permit, returning it to the semaphore.

--- a/codebase/src/cpp/syscommon/include/syscommon/concurrent/Thread.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/concurrent/Thread.h
@@ -264,7 +264,7 @@ namespace syscommon
 			 * @throw InterruptedException if the current thread was interrupted before the join 
 			 * operation could complete
 			 */
-			void join() throw ( InterruptedException );
+			void join() noexcept( false );
 
 			/**
 			 * Blocks the current thread until either this thread instance has completed executing
@@ -279,7 +279,7 @@ namespace syscommon
 			 * @throw InterruptedException if the current thread was interrupted before the join 
 			 * operation could complete
 			 */
-			bool join( unsigned long millis ) throw ( InterruptedException );
+			bool join( unsigned long millis ) noexcept( false );
 
 			/**
 			 * Accepts an IInterruptable visitor, exposing the thread's interrupt handle to the 
@@ -318,9 +318,11 @@ namespace syscommon
 			 *
 			 * Note: This call may be interrupted by other threads.
 			 *
-			 * @return A WaitResult indicating the manner in which the skeep() operation completed.
+			 * @throw InterruptedException
+			 *
+			 * @return A WaitResult indicating the manner in which the sleep() operation completed.
 			 */
-			static void sleep( unsigned long millis ) throw ( InterruptedException );
+			static void sleep( unsigned long millis ) noexcept( false );
 			static void threadEntry( void* threadInstance );
 			
 		private:

--- a/codebase/src/cpp/syscommon/include/syscommon/io/InputBuffer.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/io/InputBuffer.h
@@ -48,23 +48,53 @@ namespace syscommon
 		//                    INSTANCE METHODS
 		//----------------------------------------------------------
 		public:
-			unsigned char readUInt8() throw ( IOException );
-			char readInt8() throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			unsigned char readUInt8() noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			char readInt8() noexcept( false );
 
-			unsigned short readUInt16() throw ( IOException );
-			short readInt16() throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			unsigned short readUInt16() noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			short readInt16() noexcept( false );
 
-			unsigned int readUInt32() throw ( IOException );
-			int readInt32() throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			unsigned int readUInt32() noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			int readInt32() noexcept( false );
 
-			unsigned long long readUInt64() throw ( IOException );
-			long long readInt64() throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			unsigned long long readUInt64() noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			long long readInt64() noexcept( false );
 
-			std::string readUTF() throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			std::string readUTF() noexcept( false );
 
 		private:
 			size_t getBytesRemaining() const;
-			void readAndCopy( size_t length, char* dest ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void readAndCopy( size_t length, char* dest ) noexcept( false );
 
 		//----------------------------------------------------------
 		//                     STATIC METHODS

--- a/codebase/src/cpp/syscommon/include/syscommon/io/OutputBuffer.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/io/OutputBuffer.h
@@ -48,26 +48,56 @@ namespace syscommon
 		//                    INSTANCE METHODS
 		//----------------------------------------------------------
 		public:
-			void writeUInt8( unsigned char value ) throw ( IOException );
-			void writeInt8( char value ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void writeUInt8( unsigned char value ) noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			void writeInt8( char value ) noexcept( false );
 
-			void writeUInt16( unsigned short value ) throw ( IOException );
-			void writeInt16( short value ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void writeUInt16( unsigned short value ) noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			void writeInt16( short value ) noexcept( false );
 
-			void writeUInt32( unsigned int value ) throw ( IOException );
-			void writeInt32( int value ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void writeUInt32( unsigned int value ) noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			void writeInt32( int value ) noexcept( false );
 
-			void writeUInt64( unsigned long long value ) throw ( IOException );
-			void writeInt64( long long value ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void writeUInt64( unsigned long long value ) noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			void writeInt64( long long value ) noexcept( false );
 
-			void writeUTF( const std::string& value ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void writeUTF( const std::string& value ) noexcept( false );
 
 			size_t getLength();
 			const char* getData();
 
 		private:
 			size_t getBytesRemaining();
-			void write( size_t length, const char* source ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void write( size_t length, const char* source ) noexcept( false );
 
 		//----------------------------------------------------------
 		//                     STATIC METHODS

--- a/codebase/src/cpp/syscommon/include/syscommon/net/MulticastSocket.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/net/MulticastSocket.h
@@ -59,67 +59,82 @@ namespace syscommon
 		//                      CONSTRUCTORS
 		//----------------------------------------------------------
 		public:
-			MulticastSocket() throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			MulticastSocket() noexcept( false );
 
 			/**
 			 * Creates a multicast socket and binds it to a specific port.
 			 *
 			 * @param port the port number to bind to
+			 * @throws IOException
 			 */
-			MulticastSocket( unsigned short port ) throw ( IOException );
+			MulticastSocket( unsigned short port ) noexcept( false );
 
 			/**
 			 * Creates a MulticastSocket bound to the specified socket address
+			 *
+			 * @throws IOException
 			 */
-			MulticastSocket( const InetSocketAddress& bindAddress ) throw ( IOException );
+			MulticastSocket( const InetSocketAddress& bindAddress ) noexcept( false );
 
 			virtual ~MulticastSocket();
 
 		private:
 			/**
 			 * Internal constructor helper
+			 *
+			 * @throws IOException
 			 */
-			void _MulticastSocket( const InetSocketAddress& bindAddress ) throw ( IOException );
+			void _MulticastSocket( const InetSocketAddress& bindAddress ) noexcept( false );
 
 		//----------------------------------------------------------
 		//                    INSTANCE METHODS
 		//----------------------------------------------------------
 		public:
-			void setTimeToLive( int ttl ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void setTimeToLive( int ttl ) noexcept( false );
 
 			/**
 			 * Joins a multicast group
 			 *
 			 * @param mcastaddr the multicast address to join
+			 * @throws IOException
 			 */
-			void joinGroup( NATIVE_IP_ADDRESS mcastAddress ) throw ( IOException );
+			void joinGroup( NATIVE_IP_ADDRESS mcastAddress ) noexcept( false );
 
 			/**
 			 * Joins the specified multicast group at the specified interface.
 			 * 
 			 * @param mcastaddr the multicast address to join
 			 * @param netIf the local interface to receive multicast datagram packets
+			 * @throws IOException
 			 */
 			void joinGroup( const InetSocketAddress& mcastAddress, 
-							NATIVE_IP_ADDRESS netIf ) 			
-				throw ( IOException );
+							NATIVE_IP_ADDRESS netIf )
+				noexcept( false );
 
 			/**
 			 * Leaves a multicast group.
 			 * 
 			 * @param mcastaddr the multicast address to leave
+			 * @throws IOException
 			 */
-			void leaveGroup( NATIVE_IP_ADDRESS mcastAddress ) throw ( IOException );
+			void leaveGroup( NATIVE_IP_ADDRESS mcastAddress ) noexcept( false );
 
 			/**
 			 * Leaves a multicast group on a specified local interface.
 			 * 
 			 * @param mcastaddr is the multicast address to leave
 			 * @param netIf the local interface
+			 * @throws IOException
 			 */
 			void leaveGroup( const InetSocketAddress& mcastAddress, 
 							 NATIVE_IP_ADDRESS netIf )
-				throw ( IOException );
+				noexcept( false );
 
 			/**
 			 * Closes this multicast socket.
@@ -149,7 +164,7 @@ namespace syscommon
 			 *
 			 * @throw IOException if the socket was closed before a packet could be received
 			 */
-			void receive( DatagramPacket& packet ) throw ( IOException );
+			void receive( DatagramPacket& packet ) noexcept( false );
 
 			/**
 			 * Sends a datagram packet from this socket. The DatagramPacket includes information 
@@ -160,12 +175,18 @@ namespace syscommon
 			 *
 			 * @throw IOException if an I/O error occurs while sending the packet
 			 */
-			void send( DatagramPacket& packet ) throw ( IOException );
+			void send( DatagramPacket& packet ) noexcept( false );
 
 		private:
 			bool isCreated();
-			void create() throw ( IOException );
-			void bind( const InetSocketAddress& address ) throw ( IOException );
+			/**
+			 * @throws IOException
+			 */
+			void create() noexcept( false );
+			/**
+			 * @throws IOException
+			 */
+			void bind( const InetSocketAddress& address ) noexcept( false );
 
 		//----------------------------------------------------------
 		//                     STATIC METHODS

--- a/codebase/src/cpp/syscommon/include/syscommon/net/ServerSocket.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/net/ServerSocket.h
@@ -70,7 +70,7 @@ namespace syscommon
 			 *
 			 * @exception  IOException  if an I/O error occurs when opening the socket.
 			 */
-			ServerSocket( unsigned short port ) throw ( IOException );
+			ServerSocket( unsigned short port ) noexcept( false );
 
 			/**
 			 * Creates a server socket and binds it to the specified local port number, with the 
@@ -92,7 +92,7 @@ namespace syscommon
 			 *
 			 * @exception  IOException  if an I/O error occurs when opening the socket.
 			 */
-			ServerSocket( unsigned short port, int backlog ) throw ( IOException );
+			ServerSocket( unsigned short port, int backlog ) noexcept( false );
 
 			/**
 			 * Create a server with the specified port, listen backlog, and local IP address to 
@@ -119,7 +119,8 @@ namespace syscommon
 			 */
 			ServerSocket( unsigned short port, 
 			              int backlog, 
-						  NATIVE_IP_ADDRESS bindAddr ) throw ( IOException );
+						  NATIVE_IP_ADDRESS bindAddr )
+				noexcept( false );
 
 			virtual ~ServerSocket();
 
@@ -142,7 +143,7 @@ namespace syscommon
 			 * @param   endpoint        The IP address & port number to bind to.
 			 * @throws  IOException if the bind operation fails, or if the socket is already bound.
 			 */
-			void bind( const InetSocketAddress& endpoint ) throw ( IOException );
+			void bind( const InetSocketAddress& endpoint ) noexcept( false );
 
 			/**
 			 * Binds the <code>ServerSocket</code> to a specific address (IP address and port 
@@ -160,7 +161,7 @@ namespace syscommon
 			 */
 			void bind( const InetSocketAddress& endpoint, 
 			           int backlog ) 
-				throw ( IOException );
+				noexcept( false );
 
 			/**
 			 * Returns the local address of this server socket.
@@ -195,7 +196,7 @@ namespace syscommon
 			 *
 			 * @return the new Socket
 			 */
-			Socket* accept() throw ( IOException );
+			Socket* accept() noexcept( false );
 
 			/**
 			 * Closes this socket.
@@ -205,7 +206,7 @@ namespace syscommon
 			 *
 			 * @exception  IOException  if an I/O error occurs when closing the socket.
 			 */
-			void close() throw ( IOException );		
+			void close() noexcept( false );
 
 			/**
 			 * Returns the binding state of the ServerSocket.
@@ -222,7 +223,10 @@ namespace syscommon
 			bool isClosed();
 
 		private:
-			NATIVE_SOCKET getImpl() throw ( SocketException );
+			/**
+			 * @throws SocketException
+			 */
+			NATIVE_SOCKET getImpl() noexcept( false );
 
 		//----------------------------------------------------------
 		//                     STATIC METHODS

--- a/codebase/src/cpp/syscommon/include/syscommon/net/Socket.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/net/Socket.h
@@ -62,7 +62,7 @@ namespace syscommon
 			 *
 			 * @throws IOException if an I/O error occurs when creating the socket.
 			 */
-			Socket( NATIVE_IP_ADDRESS address, unsigned short port ) throw ( IOException );
+			Socket( NATIVE_IP_ADDRESS address, unsigned short port ) noexcept( false );
 
 			virtual ~Socket();
 
@@ -89,7 +89,7 @@ namespace syscommon
 			 * @param	endpoint the InetSocketAddress of the server to connect to
 			 * @throws	IOException if an error occurs during the connection
 			 */
-			void connect( const InetSocketAddress& endpoint ) throw ( IOException );
+			void connect( const InetSocketAddress& endpoint ) noexcept( false );
 
 			/**
 			 * Connects this socket to the server with a specified timeout value. A timeout of 
@@ -101,7 +101,7 @@ namespace syscommon
 			 * @throws  IOException if an error occurs during the connection
 			 * @throws	SocketTimeoutException if timeout expires before connecting
 			 */
-			void connect( const InetSocketAddress& endpoint, int timeout ) throw ( IOException );
+			void connect( const InetSocketAddress& endpoint, int timeout ) noexcept( false );
 
 			/**
 			 * Returns the closed state of the socket.
@@ -121,7 +121,7 @@ namespace syscommon
 			 *
 			 * @exception IOException if an I/O error occurs when closing this socket.
 			 */
-			void close() throw ( IOException );
+			void close() noexcept( false );
 			
 			/**
 			 * Sends the bytes contained in the specified buffer to the server this socket is
@@ -135,7 +135,7 @@ namespace syscommon
 			 * @throws IOException if an I/O error occurs while attempting to send the data
 			 * through the socket
 			 */
-			int send( const char* buffer, int length ) throw ( IOException );
+			int send( const char* buffer, int length ) noexcept( false );
 
 			/**
 			 * Receives data from the socket into the provided buffer
@@ -148,7 +148,7 @@ namespace syscommon
 			 * @throws IOException if an I/O error occurs while attempting to send the data through
 			 * the socket
 			 */
-			int receive( char* buffer, int length ) throw ( IOException );
+			int receive( char* buffer, int length ) noexcept( false );
 
 			/**
 			 * Returns the address to which the socket is connected.
@@ -206,7 +206,7 @@ namespace syscommon
 			 *
 			 * @exception IOException if an I/O error occurs when shutting down this socket.
 			 */
-			void shutdownInput() throw ( IOException );
+			void shutdownInput() noexcept( false );
 
 			/**
 			 * Returns whether the write-half of the socket connection is closed.
@@ -225,11 +225,14 @@ namespace syscommon
 			 * @exception IOException if an I/O error occurs when shutting down this
 			 * socket.
 			 */
-			void shutdownOutput() throw ( IOException );
+			void shutdownOutput() noexcept( false );
 
 		private:
 			bool isCreated() const;
-			void create() throw ( SocketException );
+			/**
+			 * @throws SocketException
+			 */
+			void create() noexcept( false );
 
 		//----------------------------------------------------------
 		//                     STATIC METHODS

--- a/codebase/src/cpp/syscommon/include/syscommon/util/Properties.h
+++ b/codebase/src/cpp/syscommon/include/syscommon/util/Properties.h
@@ -132,7 +132,7 @@ namespace syscommon
 			 *
 			 * @throws IOException if the file was not read successfully
 			 */
-			void loadFromFile( const tchar* filename ) throw ( IOException );
+			void loadFromFile( const tchar* filename ) noexcept( false );
 
 			/**
 			 * @see Properties::loadFromFile(const tchar*)
@@ -142,7 +142,7 @@ namespace syscommon
 			 *
 			 * @return true if the file was read successfully, otherwise false.
 			 */
-			void loadFromFile( const tchar* filename, Logger* logger ) throw ( IOException );
+			void loadFromFile( const tchar* filename, Logger* logger ) noexcept( false );
 
 			/**
 			 * Populates the provided set with the list of property names contained within this

--- a/codebase/src/cpp/syscommon/src/InputBuffer.cpp
+++ b/codebase/src/cpp/syscommon/src/InputBuffer.cpp
@@ -41,7 +41,7 @@ InputBuffer::~InputBuffer()
 //----------------------------------------------------------
 //                    INSTANCE METHODS
 //----------------------------------------------------------
-unsigned char InputBuffer::readUInt8() throw ( IOException )
+unsigned char InputBuffer::readUInt8()
 {
 	char asBytes[sizeof(unsigned char)];
 	this->readAndCopy( sizeof(unsigned char), asBytes );
@@ -49,7 +49,7 @@ unsigned char InputBuffer::readUInt8() throw ( IOException )
 	return *((unsigned char*)asBytes);
 }
 
-char InputBuffer::readInt8() throw ( IOException )
+char InputBuffer::readInt8()
 {
 	char asBytes[sizeof(char)];
 	this->readAndCopy( sizeof(char), asBytes );
@@ -57,7 +57,7 @@ char InputBuffer::readInt8() throw ( IOException )
 	return *((char*)asBytes);
 }
 
-unsigned short InputBuffer::readUInt16() throw ( IOException )
+unsigned short InputBuffer::readUInt16()
 {
 	union 
 	{ 
@@ -70,7 +70,7 @@ unsigned short InputBuffer::readUInt16() throw ( IOException )
 	return unionUInt16.value;
 }
 
-short InputBuffer::readInt16() throw ( IOException )
+short InputBuffer::readInt16()
 {
 	union
 	{
@@ -83,7 +83,7 @@ short InputBuffer::readInt16() throw ( IOException )
 	return unionInt16.value;
 }
 
-unsigned int InputBuffer::readUInt32() throw ( IOException )
+unsigned int InputBuffer::readUInt32()
 {
 	union
 	{
@@ -96,7 +96,7 @@ unsigned int InputBuffer::readUInt32() throw ( IOException )
 	return unionUInt32.value;
 }
 
-int InputBuffer::readInt32() throw ( IOException )
+int InputBuffer::readInt32()
 {
 	union
 	{
@@ -108,7 +108,7 @@ int InputBuffer::readInt32() throw ( IOException )
 	return unionInt32.value;
 }
 
-unsigned long long InputBuffer::readUInt64() throw ( IOException )
+unsigned long long InputBuffer::readUInt64()
 {
 	union
 	{
@@ -120,7 +120,7 @@ unsigned long long InputBuffer::readUInt64() throw ( IOException )
 	return unionUInt64.value;
 }
 
-long long InputBuffer::readInt64() throw ( IOException )
+long long InputBuffer::readInt64()
 {
 	union
 	{
@@ -132,7 +132,7 @@ long long InputBuffer::readInt64() throw ( IOException )
 	return unionInt64.value;
 }
 
-std::string InputBuffer::readUTF() throw ( IOException )
+std::string InputBuffer::readUTF()
 {
 	size_t size = (size_t)readUInt16();
 	if( this->getBytesRemaining() >= size )
@@ -153,7 +153,7 @@ size_t InputBuffer::getBytesRemaining() const
 	return this->dataLength - this->readMarker;
 }
 
-void InputBuffer::readAndCopy( size_t length, char* dest ) throw ( IOException )
+void InputBuffer::readAndCopy( size_t length, char* dest )
 {
 	if( this->getBytesRemaining() >= length )
 	{

--- a/codebase/src/cpp/syscommon/src/MulticastSocket.cpp
+++ b/codebase/src/cpp/syscommon/src/MulticastSocket.cpp
@@ -26,19 +26,19 @@ using namespace syscommon;
 //----------------------------------------------------------
 //                      CONSTRUCTORS
 //----------------------------------------------------------
-MulticastSocket::MulticastSocket() throw ( IOException )
+MulticastSocket::MulticastSocket()
 {
 	InetSocketAddress bindAddress( 0 );
 	_MulticastSocket( bindAddress );
 }
 
-MulticastSocket::MulticastSocket( unsigned short port ) throw ( IOException )
+MulticastSocket::MulticastSocket( unsigned short port )
 {
 	InetSocketAddress bindAddress( port );
 	_MulticastSocket( bindAddress );
 }
 
-MulticastSocket::MulticastSocket( const InetSocketAddress& bindAddress ) throw ( IOException )
+MulticastSocket::MulticastSocket( const InetSocketAddress& bindAddress )
 {
 	_MulticastSocket( bindAddress );
 }
@@ -49,8 +49,7 @@ MulticastSocket::~MulticastSocket()
 	Platform::cleanupSocketFramework();
 }
 
-void MulticastSocket::_MulticastSocket( const InetSocketAddress& bindAddress )  
-	throw ( IOException )
+void MulticastSocket::_MulticastSocket( const InetSocketAddress& bindAddress )
 {
 	// Uninitialised in ~MulticastSocket
 	Platform::initialiseSocketFramework();
@@ -62,7 +61,7 @@ void MulticastSocket::_MulticastSocket( const InetSocketAddress& bindAddress )
 	bind( bindAddress );
 }
 
-void MulticastSocket::setTimeToLive( int ttl ) throw ( IOException )
+void MulticastSocket::setTimeToLive( int ttl )
 {
 	if( !isCreated() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -75,15 +74,14 @@ void MulticastSocket::setTimeToLive( int ttl ) throw ( IOException )
 				  sizeof(int) );
 }
 
-void MulticastSocket::joinGroup( NATIVE_IP_ADDRESS mcastAddress )  throw ( IOException )
+void MulticastSocket::joinGroup( NATIVE_IP_ADDRESS mcastAddress )
 {
 	InetSocketAddress address( mcastAddress, 0 );
 	joinGroup( address, INADDR_ANY );
 }
 
 void MulticastSocket::joinGroup( const InetSocketAddress& mcastAddress, 
-								 NATIVE_IP_ADDRESS netIf )  
-	throw ( IOException )
+								 NATIVE_IP_ADDRESS netIf )
 {
 	if( !isCreated() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -107,7 +105,7 @@ void MulticastSocket::joinGroup( const InetSocketAddress& mcastAddress,
 		throw SocketException( Platform::describeLastSocketError() );
 }
 
-void MulticastSocket::leaveGroup( NATIVE_IP_ADDRESS mcastAddress ) throw ( IOException )
+void MulticastSocket::leaveGroup( NATIVE_IP_ADDRESS mcastAddress )
 {
 	InetSocketAddress address( mcastAddress, 0 );
 	leaveGroup( address, INADDR_ANY );
@@ -115,7 +113,6 @@ void MulticastSocket::leaveGroup( NATIVE_IP_ADDRESS mcastAddress ) throw ( IOExc
 
 void MulticastSocket::leaveGroup( const InetSocketAddress& mcastAddress, 
 								  NATIVE_IP_ADDRESS netIf )
-	throw ( IOException )
 {
 	if( !isCreated() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -167,7 +164,7 @@ bool MulticastSocket::isBound() const
 	return this->bound;
 }
 
-void MulticastSocket::receive( DatagramPacket& packet ) throw ( IOException )
+void MulticastSocket::receive( DatagramPacket& packet )
 {
 	if( !isCreated() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -206,7 +203,7 @@ void MulticastSocket::receive( DatagramPacket& packet ) throw ( IOException )
 	}
 }
 
-void MulticastSocket::send( DatagramPacket& packet ) throw ( IOException )
+void MulticastSocket::send( DatagramPacket& packet )
 {
 	if( !isBound() )
 		throw SocketException( TEXT("Socket is not bound") );
@@ -257,7 +254,7 @@ bool MulticastSocket::isCreated()
 	return created;
 }
 
-void MulticastSocket::create() throw ( IOException )
+void MulticastSocket::create()
 {
 	if( isCreated() )
 		throw SocketException( TEXT("Socket already created") );
@@ -277,7 +274,7 @@ void MulticastSocket::create() throw ( IOException )
 }
 
 
-void MulticastSocket::bind( const InetSocketAddress& bindAddress ) throw ( IOException )
+void MulticastSocket::bind( const InetSocketAddress& bindAddress )
 {
 	if( !isCreated() )
 		throw SocketException( TEXT("Socket is closed") );

--- a/codebase/src/cpp/syscommon/src/OutputBuffer.cpp
+++ b/codebase/src/cpp/syscommon/src/OutputBuffer.cpp
@@ -45,47 +45,47 @@ OutputBuffer::~OutputBuffer()
 //----------------------------------------------------------
 //                    INSTANCE METHODS
 //----------------------------------------------------------
-void OutputBuffer::writeUInt8( unsigned char value ) throw ( IOException )
+void OutputBuffer::writeUInt8( unsigned char value )
 {
 	this->write( sizeof(unsigned char), (char*)&value );
 }
 
-void OutputBuffer::writeInt8( char value ) throw ( IOException )
+void OutputBuffer::writeInt8( char value )
 {
 	this->write( sizeof(char), (char*)&value );
 }
 
-void OutputBuffer::writeUInt16( unsigned short value ) throw ( IOException )
+void OutputBuffer::writeUInt16( unsigned short value )
 {
 	this->write( sizeof(unsigned short), (char*)&value );
 }
 
-void OutputBuffer::writeInt16( short value ) throw ( IOException )
+void OutputBuffer::writeInt16( short value )
 {
 	this->write( sizeof(short), (char*)&value );
 }
 
-void OutputBuffer::writeUInt32( unsigned int value ) throw ( IOException )
+void OutputBuffer::writeUInt32( unsigned int value )
 {
 	this->write( sizeof(unsigned int), (char*)&value );
 }
 
-void OutputBuffer::writeInt32( int value ) throw ( IOException )
+void OutputBuffer::writeInt32( int value )
 {
 	this->write( sizeof(int), (char*)&value );
 }
 
-void OutputBuffer::writeUInt64( unsigned long long value ) throw ( IOException )
+void OutputBuffer::writeUInt64( unsigned long long value )
 {
 	this->write( sizeof(unsigned long long), (char*)&value );
 }
 
-void OutputBuffer::writeInt64( long long value ) throw ( IOException )
+void OutputBuffer::writeInt64( long long value )
 {
 	this->write( sizeof(long long), (char*)&value );
 }
 
-void OutputBuffer::writeUTF( const std::string& value ) throw ( IOException )
+void OutputBuffer::writeUTF( const std::string& value )
 {
 	size_t length = value.length();
 	this->writeUInt16( (unsigned short)length );
@@ -119,7 +119,7 @@ size_t OutputBuffer::getBytesRemaining()
 	return this->dataLength - writeMarker;
 }
 
-void OutputBuffer::write( size_t length, const char* source ) throw ( IOException )
+void OutputBuffer::write( size_t length, const char* source )
 {
 	if( this->getBytesRemaining() >= length )
 	{

--- a/codebase/src/cpp/syscommon/src/Properties.cpp
+++ b/codebase/src/cpp/syscommon/src/Properties.cpp
@@ -92,12 +92,12 @@ void Properties::putAll( const Properties& other )
 	}
 }
 
-void Properties::loadFromFile( const tchar* filename ) throw ( IOException )
+void Properties::loadFromFile( const tchar* filename )
 {
 	return loadFromFile( filename, NULL );
 }
 
-void Properties::loadFromFile( const tchar* filename, Logger* logger ) throw ( IOException )
+void Properties::loadFromFile( const tchar* filename, Logger* logger )
 {
 	if( !Platform::fileExists(filename) )
 		throw FileNotFoundException( TEXT("File does not exist") );

--- a/codebase/src/cpp/syscommon/src/Semaphore.cpp
+++ b/codebase/src/cpp/syscommon/src/Semaphore.cpp
@@ -61,12 +61,12 @@ void Semaphore::_Semaphore( unsigned int permits, const String& name )
 	this->initialised = Platform::initialiseSemaphore( this->nativeSemaphore, permits, name );
 }
 
-void Semaphore::acquire() throw ( InterruptedException )
+void Semaphore::acquire()
 {
 	this->tryAcquire( NATIVE_INFINITE_WAIT );
 }
 
-bool Semaphore::tryAcquire( unsigned long timeoutMillis ) throw ( InterruptedException )
+bool Semaphore::tryAcquire( unsigned long timeoutMillis )
 {
 	bool acquired = false;
 	if ( this->initialised )

--- a/codebase/src/cpp/syscommon/src/ServerSocket.cpp
+++ b/codebase/src/cpp/syscommon/src/ServerSocket.cpp
@@ -34,13 +34,13 @@ ServerSocket::ServerSocket()
 	_ServerSocket();
 }
 
-ServerSocket::ServerSocket( unsigned short port ) throw ( IOException )
+ServerSocket::ServerSocket( unsigned short port )
 {
 	_ServerSocket();
 	this->bind( InetSocketAddress(port) );
 }
 
-ServerSocket::ServerSocket( unsigned short port, int backlog ) throw ( IOException )
+ServerSocket::ServerSocket( unsigned short port, int backlog )
 {
 	_ServerSocket();
 	this->bind( InetSocketAddress(port), backlog );
@@ -48,7 +48,7 @@ ServerSocket::ServerSocket( unsigned short port, int backlog ) throw ( IOExcepti
 
 ServerSocket::ServerSocket( unsigned short port, 
 			                int backlog, 
-						    NATIVE_IP_ADDRESS bindAddr) throw ( IOException )
+						    NATIVE_IP_ADDRESS bindAddr)
 {
 	_ServerSocket();
 	this->bind( InetSocketAddress(bindAddr, port), backlog );
@@ -70,14 +70,13 @@ void ServerSocket::_ServerSocket()
 //----------------------------------------------------------
 //                    INSTANCE METHODS
 //----------------------------------------------------------
-void ServerSocket::bind( const InetSocketAddress& endpoint ) throw ( IOException )
+void ServerSocket::bind( const InetSocketAddress& endpoint )
 {
 	this->bind( endpoint, DEFAULT_BACKLOG );
 }
 
 void ServerSocket::bind( const InetSocketAddress& endpoint, 
-			             int backlog ) 
-	throw ( IOException )
+			             int backlog )
 {
 	if( isClosed() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -140,7 +139,7 @@ unsigned short ServerSocket::getLocalPort()
 		return 0;
 }
 
-Socket* ServerSocket::accept() throw ( IOException )
+Socket* ServerSocket::accept()
 {
 	if( isClosed() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -163,7 +162,7 @@ Socket* ServerSocket::accept() throw ( IOException )
 	}
 }
 
-void ServerSocket::close() throw ( IOException )
+void ServerSocket::close()
 {
 	NATIVE_SOCKET impl = getImpl();
 	this->closeLock.lock();
@@ -208,7 +207,7 @@ bool ServerSocket::isClosed()
 	return localClosed;
 }
 
-NATIVE_SOCKET ServerSocket::getImpl() throw ( SocketException )
+NATIVE_SOCKET ServerSocket::getImpl()
 {
 	if( this->nativeSocket == NATIVE_SOCKET_UNINIT )
 	{

--- a/codebase/src/cpp/syscommon/src/Socket.cpp
+++ b/codebase/src/cpp/syscommon/src/Socket.cpp
@@ -35,7 +35,7 @@ Socket::Socket()
 	_Socket();
 }
 
-Socket::Socket( NATIVE_IP_ADDRESS address, unsigned short port ) throw ( IOException )
+Socket::Socket( NATIVE_IP_ADDRESS address, unsigned short port )
 {	
 	_Socket();
 	InetSocketAddress endpoint( address, port );
@@ -71,7 +71,7 @@ bool Socket::isCreated() const
 	return this->created;
 }
 
-void Socket::create() throw ( SocketException )
+void Socket::create()
 {
 	if( isCreated() )
 		throw SocketException( TEXT("Socket has already been created") );
@@ -90,7 +90,7 @@ bool Socket::isConnected() const
 	return this->remoteAddress != INADDR_NONE;
 }
 
-void Socket::connect( const InetSocketAddress& endpoint ) throw ( IOException )
+void Socket::connect( const InetSocketAddress& endpoint )
 {
 	if( isClosed() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -130,7 +130,7 @@ void Socket::connect( const InetSocketAddress& endpoint ) throw ( IOException )
 	}
 }
 
-void Socket::connect( const InetSocketAddress& endpoint, int timeout ) throw ( IOException )
+void Socket::connect( const InetSocketAddress& endpoint, int timeout )
 {
 	// If no timeout was specified, then call the non-timeout version of connect
 	if( timeout <= 0 )
@@ -217,7 +217,7 @@ bool Socket::isClosed() const
 	return this->closed;
 }
 
-void Socket::close() throw ( IOException )
+void Socket::close()
 {
 	if( !isClosed() )
 	{
@@ -246,7 +246,7 @@ void Socket::close() throw ( IOException )
 	}
 }
 
-int Socket::send( const char* buffer, int length ) throw ( IOException )
+int Socket::send( const char* buffer, int length )
 {
 	if( isClosed() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -269,7 +269,7 @@ int Socket::send( const char* buffer, int length ) throw ( IOException )
 	return result;
 }
 
-int Socket::receive( char* buffer, int length ) throw ( IOException )
+int Socket::receive( char* buffer, int length )
 {
 	if( isClosed() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -312,7 +312,7 @@ bool Socket::isInputShutdown() const
 	return this->inputShutdown;
 }
 
-void Socket::shutdownInput() throw ( IOException )
+void Socket::shutdownInput()
 {
 	if( isClosed() )
 		throw SocketException( TEXT("Socket is closed") );
@@ -337,7 +337,7 @@ bool Socket::isOutputShutdown() const
 	return this->outputShutdown;
 }
 
-void Socket::shutdownOutput() throw ( IOException )
+void Socket::shutdownOutput()
 {
 	if( isClosed() )
 		throw SocketException( TEXT("Socket is closed") );

--- a/codebase/src/cpp/syscommon/src/Thread.cpp
+++ b/codebase/src/cpp/syscommon/src/Thread.cpp
@@ -149,7 +149,7 @@ bool Thread::isAlive() const
  * @throw InterruptedException if the current thread was interrupted before the join 
  * operation could complete
  */
-void Thread::join() throw ( InterruptedException )
+void Thread::join()
 {
 	// Join the thread with INFINITE timeout
 	this->join( NATIVE_INFINITE_WAIT );
@@ -165,7 +165,7 @@ void Thread::join() throw ( InterruptedException )
  * @throw InterruptedException if the current thread was interrupted before the join 
  * operation could complete
  */
-bool Thread::join( unsigned long millis ) throw ( InterruptedException )
+bool Thread::join( unsigned long millis )
 {	
 	// The commented code below was how the join was originally done, however it was creating a 
 	// buttload of race conditions, so I've just used an event to signal the join instead
@@ -295,7 +295,7 @@ Thread* Thread::currentThread()
  * @throw InterruptedException if the current thread was interrupted before the sleep
  * operation could complete
  */
-void Thread::sleep( unsigned long millis ) throw ( InterruptedException )
+void Thread::sleep( unsigned long millis )
 {
 	Thread* thisThread = Thread::currentThread();
 	if ( thisThread && thisThread->interruptInitialised )

--- a/codebase/src/cpp/test/SocketTest.cpp
+++ b/codebase/src/cpp/test/SocketTest.cpp
@@ -945,7 +945,7 @@ void SocketTest::testShutdownOutputAlreadyShutdown()
 	}
 }
 
-void SocketTest::quickStringSend( const string& message ) throw ( IOException )
+void SocketTest::quickStringSend( const string& message )
 {
 	size_t length = message.length();
 	
@@ -953,7 +953,7 @@ void SocketTest::quickStringSend( const string& message ) throw ( IOException )
 	this->socket->send( (char*)message.data(), length );
 }
 
-string SocketTest::quickStringReceive() throw ( IOException )
+string SocketTest::quickStringReceive()
 {
 	// Receive the data length
 	size_t length = 0;

--- a/codebase/src/cpp/test/SocketTest.h
+++ b/codebase/src/cpp/test/SocketTest.h
@@ -87,8 +87,14 @@ class SocketTest: public CppUnit::TestFixture
 		void testShutdownOutputAlreadyShutdown();
 
 	private:
-		void quickStringSend( const string& message ) throw ( IOException );
-		string quickStringReceive() throw ( IOException );
+		/**
+		 * @throws IOException
+		 */
+		void quickStringSend( const string& message ) noexcept( false );
+		/**
+		 * @throws IOException
+		 */
+		string quickStringReceive() noexcept( false );
 
 	//----------------------------------------------------------
 	//                     STATIC METHODS

--- a/codebase/src/cpp/test/StringConnection.cpp
+++ b/codebase/src/cpp/test/StringConnection.cpp
@@ -50,7 +50,7 @@ StringConnection::~StringConnection()
 //----------------------------------------------------------
 //                    INSTANCE METHODS
 //----------------------------------------------------------
-void StringConnection::start() throw ( IOException )
+void StringConnection::start()
 {
 	if( !this->receiveThread )
 	{
@@ -71,7 +71,7 @@ void StringConnection::start() throw ( IOException )
 	}
 }
 
-void StringConnection::send( const string& data ) throw ( IOException )
+void StringConnection::send( const string& data )
 { 
 	if( this->running )
 	{
@@ -119,7 +119,7 @@ void StringConnection::join()
 	}
 }
 
-void StringConnection::receiveFully( char* buffer, int length ) throw ( IOException )
+void StringConnection::receiveFully( char* buffer, int length )
 {
 	int totalReceived = 0;
 	while( totalReceived < length )

--- a/codebase/src/cpp/test/StringConnection.h
+++ b/codebase/src/cpp/test/StringConnection.h
@@ -52,14 +52,23 @@ class StringConnection : IRunnable
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
 	public:
-		void start() throw ( IOException );
-		void send( const string& data ) throw ( IOException );
+		/**
+		 * @throws IOException
+		 */
+		void start();
+		/**
+		 * @throws IOException
+		 */
+		void send( const string& data );
 		void interrupt();
 		void join();
 		bool isRunning() const;
 
 	private:
-		void receiveFully( char* buffer, int length ) throw ( IOException );
+		/**
+		 * @throws IOException
+		 */
+		void receiveFully( char* buffer, int length );
 
 	public:
 		virtual void run();

--- a/codebase/src/cpp/test/StringServer.cpp
+++ b/codebase/src/cpp/test/StringServer.cpp
@@ -37,7 +37,7 @@ StringServer::~StringServer()
 //----------------------------------------------------------
 //                    INSTANCE METHODS
 //----------------------------------------------------------
-void StringServer::start() throw ( IOException )
+void StringServer::start()
 {
 	if( !this->acceptThread )
 	{

--- a/codebase/src/cpp/test/StringServer.h
+++ b/codebase/src/cpp/test/StringServer.h
@@ -59,7 +59,10 @@ class StringServer : IRunnable, IStringConsumer
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
 	public:
-		void start() throw ( IOException );
+		/**
+		 * @throws IOException
+		 */
+		void start();
 		void stop();
 
 		bool isStarted() const;


### PR DESCRIPTION
Dynamic Exception Specifications were deprecated in C++11 and removed in C++17.

This commit replaces dynamic throw specifications with `noexcept(false)` , with documentation added for the specified throw.

In the few places where `throw()` was present, they have been replaced with the appropriate `noexcept` specification.